### PR TITLE
ripple.com.bz

### DIFF
--- a/data/urls.yaml
+++ b/data/urls.yaml
@@ -59179,3 +59179,9 @@
   subcategory: Chainlink
   description: "Fake Chainlink airdrop phishing for secrets with POST /sign.php - promoted on twitter by @LinkChainlink (id: 1227974606448885760) and @Chainlink_Link (id: 1227617073171517442)"
   reporter: CryptoScamDB
+- name: ripple.com.bz
+  url: http://ripple.com.bz
+  category: Phishing
+  subcategory: Ripple
+  description: "Fake Ripple site phishing for secrets with POST /post.php"
+  reporter: CryptoScamDB


### PR DESCRIPTION
ripple.com.bz
Fake Ripple site phishing for secrets with POST /post.php
https://urlscan.io/result/59a908c9-81b6-4b7c-ab0c-4f960301d2a7/
https://urlscan.io/result/b5b470e3-37b3-444a-a611-1b5cbaf72e70/
https://urlscan.io/result/65cc3dd3-3de0-4bd2-8a63-24ef1d7d0e4a/