### PR TITLE
avubit.com + more

### DIFF
--- a/data/urls.yaml
+++ b/data/urls.yaml
@@ -59195,3 +59195,22 @@
     - "0x830B99a1DF212abE46C2634F4a0D26685b2B83cF"
     - "0xa5b424581C8B8037aB34cf0F3537911a8e7ACA41"
   reporter: CryptoScamDB    
+- name: avubit.com
+  url: http://avubit.com
+  category: Scamming
+  subcategory: Exchange
+  description: "Fake exchange phishing for deposits"
+  addresses:
+    LTC:
+    - "MWhbe8B8YtU8J1MsFavtkGVYqAABTKMds4"
+    ETH:
+    - "0x0C7bdabE793f84A8F8FCBa6A84EDdD7B250B6481"
+    BTC:
+    - "3CpCLbYjwXjYonyUXqdJ3pQHn5VyS6ysrn"
+  reporter: CryptoScamDB    
+- name: linkcoinairdrop.com
+  url: http://linkcoinairdrop.com
+  category: Phishing
+  subcategory: Chainlink
+  description: "Fake Chainlink airdrop phishing for secrets with POST /sign.php"
+  reporter: CryptoScamDB


### PR DESCRIPTION
avubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/58ce6e0c-811f-46b0-9bac-8d7b91ebb963/
address: MWhbe8B8YtU8J1MsFavtkGVYqAABTKMds4 (ltc)
address: 0x0C7bdabE793f84A8F8FCBa6A84EDdD7B250B6481 (eth)
address: 3CpCLbYjwXjYonyUXqdJ3pQHn5VyS6ysrn (btc)

linkcoinairdrop.com
Fake Chainlink airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/2764cf72-17a2-4e4a-a4f5-0e96d9a73773/
https://urlscan.io/result/4f1e33a4-6d26-4ef8-97b9-69cb865b7818/
https://urlscan.io/result/ad6d3331-0a6a-4b6c-b325-ec3c2f829c52/