### PR TITLE
binance2021.com + more

### DIFF
--- a/data/uris.yaml
+++ b/data/uris.yaml
@@ -1,0 +1,34 @@
+---
+- name: twitter.com/cz_binance
+  url: https://twitter.com/cz_binance
+  category: Scamming
+  subcategory: Trust-Trading
+  description: Trust trading 0.5ETH for 5ETH
+  addresses:
+    ETH:
+    - "0x08389B19ad52f0d983609ab785b3a43A0E90355F"
+  reporter: CryptoScamDB
+- name: 'Twitter: EthereumWallets'
+  url: https://twitter.com/EthereumWallets
+  category: Phishing
+  subcategory: MyEtherWallet
+  description: https://bitcointalk.org/index.php?topic=1689585.20
+  reporter: CryptoScamDB
+- name: twitter.com/VltalkButerin
+  url: https://twitter.com/VltalkButerin
+  category: Scamming
+  subcategory: Trust-Trading
+  description: Trust trading 0.1ETH for 2ETH
+  addresses:
+    ETH:
+    - "0x7bb386c33486fe345168d0af94bef03897e16022"
+  reporter: CryptoScamDB
+- name: twitter.com/Aurora__dao/status/960683836463075328
+  url: https://twitter.com/Aurora__dao/status/960683836463075328
+  category: Scamming
+  subcategory: Trust-Trading
+  description: Trust trading scam tweet
+  addresses:
+    ETH:
+    - "0xfa2e4bddb3899dFB0d91A70744739d9f76692755"
+  reporter: CryptoScamDB

--- a/data/urls.yaml
+++ b/data/urls.yaml
@@ -219,12 +219,6 @@
   subcategory: MyEtherWallet
   description: https://bitcointalk.org/index.php?topic=1689585.20
   reporter: CryptoScamDB
-- name: 'Twitter: EthereumWallets'
-  url: https://twitter.com/EthereumWallets
-  category: Phishing
-  subcategory: MyEtherWallet
-  description: https://bitcointalk.org/index.php?topic=1689585.20
-  reporter: CryptoScamDB
 - name: www.ether-wallet.net
   url: http://www.ether-wallet.net
   category: Phishing
@@ -15644,15 +15638,6 @@
     ETH:
     - "0x94763846b1fcB75fcCfcb51a9636dDc26Af281b1"
   reporter: CryptoScamDB
-- name: twitter.com/VltalkButerin
-  url: https://twitter.com/VltalkButerin
-  category: Scamming
-  subcategory: Trust-Trading
-  description: Trust trading 0.1ETH for 2ETH
-  addresses:
-    ETH:
-    - "0x7bb386c33486fe345168d0af94bef03897e16022"
-  reporter: CryptoScamDB
 - name: trinity-token.com
   url: http://trinity-token.com
   category: Phishing
@@ -21272,15 +21257,6 @@
     ETH:
     - "0x97b20481241fe3cb9cc9ba50609d377b2506cdaa"
   reporter: CryptoScamDB
-- name: twitter.com/cz_binance
-  url: https://twitter.com/cz_binance
-  category: Scamming
-  subcategory: Trust-Trading
-  description: Trust trading 0.5ETH for 5ETH
-  addresses:
-    ETH:
-    - "0x08389B19ad52f0d983609ab785b3a43A0E90355F"
-  reporter: CryptoScamDB
 - name: Fake DaoStack ICO Telegram
   url: https://t.me/daostackchannelANN
   category: Phishing
@@ -21906,15 +21882,6 @@
   addresses:
     ETH:
     - "0x299628fD380813622305517E64eee89BB6a49Ca3"
-  reporter: CryptoScamDB
-- name: twitter.com/Aurora__dao/status/960683836463075328
-  url: https://twitter.com/Aurora__dao/status/960683836463075328
-  category: Scamming
-  subcategory: Trust-Trading
-  description: Trust trading scam tweet
-  addresses:
-    ETH:
-    - "0xfa2e4bddb3899dFB0d91A70744739d9f76692755"
   reporter: CryptoScamDB
 - name: Telegram
   url: https://user-images.githubusercontent.com/2313704/39815843-3989276a-5391-11e8-8b03-5a54164e8dec.png

--- a/data/urls.yaml
+++ b/data/urls.yaml
@@ -63942,3 +63942,20 @@
   subcategory: Trust
   description: "Fake TrustWallet phishing for secrets with POST /submit.php"
   reporter: CryptoScamDB
+- name: binance2021.com
+  url: http://binance2021.com
+  category: Scamming
+  subcategory: Trust-Trading
+  description: "Trust trading scam site"
+  addresses:
+    BTC:
+    - "18v6DhnLZQ132Z1fEVW4TyNhtkmieM2qsq"
+    ETH:
+    - "0xb16742b92f8236a4b92d31b39ea041d9f4336d5f"
+  reporter: CryptoScamDB
+- name: ripple.com.so
+  url: http://ripple.com.so
+  category: Phishing
+  subcategory: Ripple
+  description: "Fake Ripple site phishing for secrets"
+  reporter: CryptoScamDB


### PR DESCRIPTION
binance2021.com
Trust trading scam site
https://urlscan.io/result/04253617-3753-47a0-adb8-0af80702461a/
https://urlscan.io/result/7875c39b-2603-4df6-a0d4-13d2cb2342eb/
https://urlscan.io/result/8a224b66-f278-47a9-9521-c4f202fe3719/
address: 18v6DhnLZQ132Z1fEVW4TyNhtkmieM2qsq (btc)
address: 0xb16742b92f8236a4b92d31b39ea041d9f4336d5f (eth)

ripple.com.so
Fake Ripple site phishing for secrets
https://urlscan.io/result/a80fc7d3-90c2-444a-b3a7-502e25948748/
https://urlscan.io/result/78eaac69-65bb-40a8-a3de-5c6ebc49dd0f/

--  

Moved alexa top 100 domains to uris file since the hostname is not bad